### PR TITLE
Output slack usernames instead of full names

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,4 @@ TOIL_SLEEPING_HOURS=REDACTED
 TOIL_WAKING_HOURS=REDACTED
 NUM_DAYS=REDACTED
 LOOK_AHEAD_MONTHS=REDACTED
+EMAIL_TO_SLACK_MAP='{"alice@example.com":"alice", "bob@example.com":"robert", "eve@example.com":"eve ", "fred@example.com":"foobar quux"}'

--- a/oncall.rb
+++ b/oncall.rb
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 # script to get the on call person for the next 4 weeks
 require 'opsgenie'
+require 'json'
 require 'date'
 require 'dotenv/load'
 
@@ -12,21 +13,27 @@ def next_wednesday
   today + days_until_wednesday
 end
 
+def get_slack_name(email, email_to_slack_map)
+  email_to_slack_map[email] || "Unknown"
+end
+
 # Fetch the schedule by its ID
 schedule = Opsgenie::Schedule.find_by_id(ENV['OPSGENIE_SCHEDULE_ID'])
+
+# Parse the email to Slack username map from the environment variable
+email_to_slack_map = JSON.parse(ENV['EMAIL_TO_SLACK_MAP'])
 
 4.times do |i|
   wednesday = next_wednesday + i*7
   puts "On call for week starting #{wednesday.strftime('%Y-%m-%d')}:"
-  
   date_time = DateTime.parse("#{wednesday.strftime('%Y-%m-%d')}T19:00:00")
   on_calls = schedule.on_calls(date_time)
-  
   if on_calls.empty?
     puts "Nobody"
   else
     on_calls.each do |user|
-      puts "#{user.full_name}"
+      slack_name = get_slack_name(user.username, email_to_slack_map)
+      puts "@#{slack_name}"
     end
   end
 end


### PR DESCRIPTION
The output of this script is pasted into a Slack channel, so it makes sense to have the output be the Slack username instead of the full name.

We do this by adding a new environment variable, EMAIL_TO_SLACK_MAP, which is a JSON object mapping email addresses to Slack usernames. This is then parsed and used to map the email addresses returned by the Opsgenie API to Slack usernames.